### PR TITLE
feat: Update KPI cards for TikTok and Instagram

### DIFF
--- a/src/components/dashboard/InstagramEngagementCard.tsx
+++ b/src/components/dashboard/InstagramEngagementCard.tsx
@@ -9,12 +9,30 @@ interface InstagramEngagementCardProps {
   cardVariants: any;
 }
 
+import { formatKpiValue } from '../../utils'; // Import the formatter
+
 const InstagramEngagementCard: React.FC<InstagramEngagementCardProps> = ({
   instagramEngagementRate,
   competitorInstagramEngagementRate,
   selectedCompetitor,
   cardVariants
 }) => {
+  const nordstromERDisplay = formatKpiValue(instagramEngagementRate, true);
+  const competitorERDisplay = formatKpiValue(competitorInstagramEngagementRate, true);
+
+  let differenceText = 'Equal engagement rates.';
+  if (instagramEngagementRate !== null && competitorInstagramEngagementRate !== null && !isNaN(Number(instagramEngagementRate)) && !isNaN(Number(competitorInstagramEngagementRate))) {
+    const difference = Number(instagramEngagementRate) - Number(competitorInstagramEngagementRate);
+    if (difference !== 0) {
+      const formattedDifference = formatKpiValue(Math.abs(difference), true);
+      if (difference > 0) {
+        differenceText = `Nordstrom has ${formattedDifference} higher engagement.`;
+      } else {
+        differenceText = `${selectedCompetitor} has ${formattedDifference} higher engagement.`;
+      }
+    }
+  }
+
   return (
     <motion.div
       custom={3}
@@ -26,27 +44,23 @@ const InstagramEngagementCard: React.FC<InstagramEngagementCardProps> = ({
       <div className="flex justify-between items-start">
         <div>
           <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Video Engagement Rate (Insta)</p>
-          <h3 className="text-3xl font-bold text-nordstrom-blue mt-1">{(instagramEngagementRate).toFixed(1)}%</h3> {/* Value is already a percentage, display with 1 decimal */}
+          <h3 className="text-3xl font-bold text-nordstrom-blue mt-1">{nordstromERDisplay}</h3>
         </div>
         <BiIcons.BiTrendingUp className="text-3xl text-nordstrom-blue/70 dark:text-nordstrom-blue/60" />
       </div>
       <div className="mt-4 text-xs text-gray-600 dark:text-gray-300">
         <div className="flex justify-between">
           <p>Nordstrom</p>
-          <p className="font-medium">{(instagramEngagementRate).toFixed(1)}%</p>
+          <p className="font-medium">{nordstromERDisplay}</p>
         </div>
         <div className="flex justify-between mt-1">
           <p>{selectedCompetitor}</p>
-          <p className="font-medium">{(competitorInstagramEngagementRate).toFixed(1)}%</p>
+          <p className="font-medium">{competitorERDisplay}</p>
         </div>
-        {instagramEngagementRate > 0 && competitorInstagramEngagementRate > 0 && (
+        {nordstromERDisplay !== "N/A" && competitorERDisplay !== "N/A" && (
           <div className="mt-2 pt-2 border-t border-gray-200 dark:border-gray-600">
             <p>
-              {instagramEngagementRate > competitorInstagramEngagementRate 
-                ? `Nordstrom has ${(instagramEngagementRate - competitorInstagramEngagementRate).toFixed(1)}% higher engagement.`
-                : instagramEngagementRate < competitorInstagramEngagementRate
-                  ? `${selectedCompetitor} has ${(competitorInstagramEngagementRate - instagramEngagementRate).toFixed(1)}% higher engagement.`
-                  : 'Equal engagement rates.'}
+              {differenceText}
             </p>
           </div>
         )}

--- a/src/components/dashboard/TikTokEngagementCard.tsx
+++ b/src/components/dashboard/TikTokEngagementCard.tsx
@@ -9,12 +9,33 @@ interface TikTokEngagementCardProps {
   cardVariants: any;
 }
 
+import { formatKpiValue } from '../../utils'; // Import the formatter
+
 const TikTokEngagementCard: React.FC<TikTokEngagementCardProps> = ({
   tikTokEngagementRate,
   competitorTikTokEngagementRate,
   selectedCompetitor,
   cardVariants
 }) => {
+  // The tikTokEngagementRate from calculateTotalMetrics is already a percentage value (e.g., 10.5 for 10.5%)
+  // and formatted to 1 decimal place. formatKpiValue will handle toFixed(2) and add '%'.
+  const nordstromERDisplay = formatKpiValue(tikTokEngagementRate, true);
+  const competitorERDisplay = formatKpiValue(competitorTikTokEngagementRate, true);
+
+  let differenceText = 'Equal engagement rates.';
+  if (tikTokEngagementRate !== null && competitorTikTokEngagementRate !== null && !isNaN(Number(tikTokEngagementRate)) && !isNaN(Number(competitorTikTokEngagementRate))) {
+    const difference = Number(tikTokEngagementRate) - Number(competitorTikTokEngagementRate);
+    if (difference !== 0) {
+      const formattedDifference = formatKpiValue(Math.abs(difference), true);
+      if (difference > 0) {
+        differenceText = `Nordstrom has ${formattedDifference} higher engagement.`;
+      } else {
+        differenceText = `${selectedCompetitor} has ${formattedDifference} higher engagement.`;
+      }
+    }
+  }
+
+
   return (
     <motion.div
       custom={4} // Ensure this custom index is unique if used with others in the same list
@@ -26,27 +47,23 @@ const TikTokEngagementCard: React.FC<TikTokEngagementCardProps> = ({
       <div className="flex justify-between items-start">
         <div>
           <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Engagement Rate (TikTok)</p>
-          <h3 className="text-3xl font-bold text-nordstrom-blue mt-1">{(tikTokEngagementRate * 100).toFixed(2)}%</h3>
+          <h3 className="text-3xl font-bold text-nordstrom-blue mt-1">{nordstromERDisplay}</h3>
         </div>
         <BiIcons.BiTrendingUp className="text-3xl text-nordstrom-blue/70 dark:text-nordstrom-blue/60" />
       </div>
       <div className="mt-4 text-xs text-gray-600 dark:text-gray-300">
         <div className="flex justify-between">
           <p>Nordstrom</p>
-          <p className="font-medium">{(tikTokEngagementRate * 100).toFixed(2)}%</p>
+          <p className="font-medium">{nordstromERDisplay}</p>
         </div>
         <div className="flex justify-between mt-1">
           <p>{selectedCompetitor}</p>
-          <p className="font-medium">{(competitorTikTokEngagementRate * 100).toFixed(2)}%</p>
+          <p className="font-medium">{competitorERDisplay}</p>
         </div>
-        {tikTokEngagementRate > 0 && competitorTikTokEngagementRate > 0 && (
+        {nordstromERDisplay !== "N/A" && competitorERDisplay !== "N/A" && (
           <div className="mt-2 pt-2 border-t border-gray-200 dark:border-gray-600">
             <p>
-              {tikTokEngagementRate > competitorTikTokEngagementRate 
-                ? `Nordstrom has ${((tikTokEngagementRate - competitorTikTokEngagementRate) * 100).toFixed(2)}% higher engagement.`
-                : tikTokEngagementRate < competitorTikTokEngagementRate
-                  ? `${selectedCompetitor} has ${((competitorTikTokEngagementRate - tikTokEngagementRate) * 100).toFixed(2)}% higher engagement.`
-                  : 'Equal engagement rates.'}
+              {differenceText}
             </p>
           </div>
         )}

--- a/src/utils/formatUtils.ts
+++ b/src/utils/formatUtils.ts
@@ -1,0 +1,23 @@
+// src/utils/formatUtils.ts
+
+export const formatKpiValue = (
+  value: number | undefined | null,
+  isPercentage: boolean = false
+): string => {
+  if (value === null || value === undefined || isNaN(Number(value))) {
+    return "N/A";
+  }
+
+  const numericValue = Number(value);
+  // Ensure we're dealing with a valid number after conversion before calling toFixed
+  if (isNaN(numericValue)) {
+    return "N/A";
+  }
+
+  const formattedValue = numericValue.toFixed(2);
+
+  if (isPercentage) {
+    return `${formattedValue}%`;
+  }
+  return formattedValue;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,7 @@
+// src/utils/index.ts
+
+export * from './formatUtils';
+export * from './chartUtils'; // Assuming this should also be here
+export * from './dataConverters'; // Assuming this should also be here
+export * from './excelUtils'; // Assuming this should also be here
+export * from './sentimentUtils'; // Assuming this should also be here


### PR DESCRIPTION
This commit implements changes to the KPI cards on the DashboardOverview:

For TikTok KPIs:
- Displays 5 KPI cards in a single row, ordered as: Total Posts, Total Plays (Views), Total Likes, Total Comments, and Engagement Rate.
- Adds a new "Total Comments" KPI card.
- Updates the Engagement Rate KPI to be calculated as: ((sum of diggCount + sum of commentCount + sum of shareCount + sum of collectCount) / sum of playCount) * 100.
- Adjusts the grid layout for TikTok KPIs to use 5 columns on large screens.

For Both Instagram and TikTok KPIs:
- All numerical KPI values displayed in the cards are now formatted to 2 decimal places.
- Engagement Rate values are formatted to 2 decimal places and include a '%' sign.
- This formatting is applied consistently, including within the specific InstagramEngagementCard and TikTokEngagementCard components.
- A new `formatKpiValue` utility was created to handle this formatting.

Instagram KPI layout remains at 4 cards per row.